### PR TITLE
look for a period at the end of a string or followed by a whitespace

### DIFF
--- a/lib/knife_cookbook_doc/resource_model.rb
+++ b/lib/knife_cookbook_doc/resource_model.rb
@@ -65,7 +65,7 @@ module KnifeCookbookDoc
     end
 
     def first_sentence(string)
-      string.gsub(/^([^.]*?\.)/m) do |match|
+      string.gsub(/^(.*?\.(\z|\s))/m) do |match|
         return $1.gsub("\n",' ').strip
       end
       return nil


### PR DESCRIPTION
If a description for a LWRP contains a filename with an extension (for example, foo.bar) the description generated for the LWRP under the "resources" section would be cut off at the file extension. For example, say the description in the LWRP is "This resource updates foo.bar file" - the description under the "resources" section would be "This resource updates foo." That's because the regex in first_sentence() looks for a first period in the string. I updated the regex to look for a period followed by a whitespace or at the end of the string.
