### PR TITLE
find attributes in the attributes/ directory if none are specified in metadata.rb file

### DIFF
--- a/lib/chef/knife/README.md.erb
+++ b/lib/chef/knife/README.md.erb
@@ -41,7 +41,7 @@
 
 <% unless attributes.empty? %>
 <% attributes.each do |name, description, default, choice| %>
-* `<%= name %>` - <%= description %>. <% unless choice.empty? %>Available options: <%= "`#{choice.join('`, `')}`" %>. <% end %>Defaults to `<%= default %>`.
+* `<%= name %>` - <%= description %><% if !description.nil? && !description.strip.end_with?(".") %>.<% end %> <% unless choice.empty? %>Available options: <%= "`#{choice.join('`, `')}`" %>. <% end %>Defaults to `<%= default %>`.
 <% end %>
 <% else %>
 *No attributes defined*

--- a/lib/chef/knife/cookbook_doc.rb
+++ b/lib/chef/knife/cookbook_doc.rb
@@ -9,6 +9,7 @@ module KnifeCookbookDoc
       require 'knife_cookbook_doc/readme_model'
       require 'knife_cookbook_doc/recipe_model'
       require 'knife_cookbook_doc/resource_model'
+      require 'knife_cookbook_doc/attributes_model'
     end
 
     banner 'knife cookbook doc DIR (options)'

--- a/lib/knife_cookbook_doc/attributes_model.rb
+++ b/lib/knife_cookbook_doc/attributes_model.rb
@@ -1,0 +1,64 @@
+module KnifeCookbookDoc
+  class AttributesModel
+
+    ATTRIBUTE_REGEX = "(^\s*default.*?)=(.*?)$".freeze
+
+    def initialize(filename)
+      @filename = filename
+      @attributes = {}
+      load_descriptions
+    end
+
+    def attributes
+      @attributes.map do |name, options|
+        [name, options[:description], options[:default], []]
+      end
+    end
+
+    private
+
+    def load_descriptions
+      resource_data = IO.read(@filename)
+
+      # find all attributes
+      resource_data.gsub(/#{ATTRIBUTE_REGEX}/) do
+        name = get_attribute_name($1)
+        value = $2.strip
+
+        if value.starts_with?("{")
+          value = "{ ... }"
+        elsif  value.starts_with?("[") 
+          value = "[ ... ]"
+        else
+          value = value.gsub(/\A\"|\A'|\"\Z|'\Z/, '')
+        end
+        
+        options = {}
+        options[:default] = value
+        @attributes[name] = options
+      end
+
+      # get/parse comments
+      resource_data = resource_data.gsub(/^=begin\s*\n\s*\#\<\s*\n(.*?)^\s*\#\>\n=end\s*\n#{ATTRIBUTE_REGEX}/m) do
+        update_attribute($2, $1)
+      end
+      resource_data = resource_data.gsub(/^\s*\#\<\n(.*?)^\s*\#\>\n#{ATTRIBUTE_REGEX}/m) do
+        update_attribute($2, $1.gsub(/^\s*\# ?/, ''))
+      end
+      resource_data = resource_data.gsub(/^\s*\#\<\>\s(.*?$)\n#{ATTRIBUTE_REGEX}/m) do
+        update_attribute($2, $1)
+      end
+    end
+
+    def update_attribute(name, description) 
+      name = get_attribute_name(name)
+      options = @attributes[name]
+      options[:description] = description.strip
+    end
+
+    def get_attribute_name(name)
+      name.strip.gsub(/^default/, "node")
+    end
+
+  end
+end


### PR DESCRIPTION
If no attributes are specified in the metadata.rb file, try to discover them under the attributes/ directory. The algorithm is not perfect but should work in most cases. All three different styles of comments are supported. Examples:
# <> Set user configuration directory.

default[:foo][:user_dir] = nil

=begin
# <

Set base directory
# >

=end
default[:foo][:base_url] = "/foo/bar"
# <
# Install version.
# >

default[:foo][:version] = "6"

The attributes in the generated documentation appear in the same order as specified in the attribute files.
