### PR TITLE
README not updated when running cookbook doc from powershell

### DIFF
--- a/lib/chef/knife/cookbook_doc.rb
+++ b/lib/chef/knife/cookbook_doc.rb
@@ -39,6 +39,8 @@ module KnifeCookbookDoc
         exit(1)
       end
 
+      cookbook_dir = File.realpath(cookbook_dir)
+
       model = ReadmeModel.new(cookbook_dir, config[:constraints])
 
       template = File.read(config[:template_file])


### PR DESCRIPTION
When running knife cookbook doc from powershell the README isn't fully updated.
