### PR TITLE
Be honest about attribute types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Be honest about attribute types. Submitted by benlangfeld.
+
 v0.10.0 (Mar 3 2014)
 --------------------
 

--- a/lib/chef/knife/README.md.erb
+++ b/lib/chef/knife/README.md.erb
@@ -41,7 +41,7 @@
 
 <% unless attributes.empty? %>
 <% attributes.each do |name, description, default, choice| %>
-* `<%= name %>` - <%= description %><% if !description.nil? && !description.strip.end_with?(".") %>.<% end %> <% unless choice.empty? %>Available options: <%= "`#{choice.join('`, `')}`" %>. <% end %>Defaults to `<%= default %>`.
+* `<%= name %>` - <%= description %><% if !description.nil? && !description.strip.end_with?(".") %>.<% end %> <% unless choice.empty? %>Available options: <%= "`#{choice.map(&:inspect).join('`, `')}`" %>. <% end %>Defaults to `<%= default.inspect %>`.
 <% end %>
 <% else %>
 *No attributes defined*


### PR DESCRIPTION
Options and default values should be printed clearly as the types they are. String are now rendered as `"value"` instead of `value`, Symbols as `:value` instead of `value` and `nil` instead of ``.
