### PR TITLE
Improve attribute regex

### DIFF
--- a/lib/knife_cookbook_doc/attributes_model.rb
+++ b/lib/knife_cookbook_doc/attributes_model.rb
@@ -1,7 +1,7 @@
 module KnifeCookbookDoc
   class AttributesModel
 
-    ATTRIBUTE_REGEX = "(^\s*default.*?)=(.*?)$".freeze
+    ATTRIBUTE_REGEX = "(^\s*(?:default|set|force_default|override|force_override).*?)=\s*(.*?)$".freeze
 
     def initialize(filename)
       @filename = filename


### PR DESCRIPTION
Currently, the attribute regex only supports the `default` precedent level and also does not support multiline definitions.  An example of a multiline that the regex currently doesn't support is:

```
default['cookbook']['attribute'] =
  "my_value"
```

With this change the regex now supports all 5 precedent specifiers and also supports multiline definitions as shown above. This is fully backward-compatible.