### PR TITLE
Fix multiline regex

### DIFF
--- a/lib/knife_cookbook_doc/attributes_model.rb
+++ b/lib/knife_cookbook_doc/attributes_model.rb
@@ -1,7 +1,7 @@
 module KnifeCookbookDoc
   class AttributesModel
 
-    ATTRIBUTE_REGEX = "(^\s*(?:default|set|force_default|override|force_override).*?)=\s*(.*?)$".freeze
+    ATTRIBUTE_REGEX = "(^\s*(?:default|set|force_default|override|force_override).*?)=\s*\n?\s*(.*?)$".freeze
 
     def initialize(filename)
       @filename = filename
@@ -57,7 +57,7 @@ module KnifeCookbookDoc
     end
 
     def get_attribute_name(name)
-      name.strip.gsub(/^default/, "node")
+      name.strip.gsub(/^(default|set|force_default|override|force_override)/, "node")
     end
 
   end


### PR DESCRIPTION
Faulty regex in #19. I actually patched my installed `knife-cookbook-doc` with this and things work now.  Sorry for the faulty PR earlier.

I also included a fix to the `get_attribute_name` since I notice it keys off the precedent level and changes it to `node`.