### PR TITLE
Fix with tests

### DIFF
--- a/knife_cookbook_doc.gemspec
+++ b/knife_cookbook_doc.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'erubis'
 
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
 end

--- a/lib/knife_cookbook_doc/attributes_model.rb
+++ b/lib/knife_cookbook_doc/attributes_model.rb
@@ -39,10 +39,10 @@ module KnifeCookbookDoc
       end
 
       # get/parse comments
-      resource_data = resource_data.gsub(/^=begin\s*\n\s*\#\<\s*\n(.*?)\n^\s*\#\>\n=end\s*\n#{ATTRIBUTE_REGEX}/) do
+      resource_data = resource_data.gsub(/^=begin\s*\n\s*\#\<\s*\n(.*?)^\s*\#\>\n=end\s*\n#{ATTRIBUTE_REGEX}/m) do
         update_attribute($2, $1)
       end
-      resource_data = resource_data.gsub(/^\s*\#\<\n(.*?)\n^\s*\#\>\n#{ATTRIBUTE_REGEX}/) do
+      resource_data = resource_data.gsub(/^\s*\#\<\n(.*?)^\s*\#\>\n#{ATTRIBUTE_REGEX}/m) do
         update_attribute($2, $1.gsub(/^\s*\# ?/, ''))
       end
       resource_data = resource_data.gsub(/^\s*\#\<\>\s(.*?$)\n#{ATTRIBUTE_REGEX}/) do

--- a/spec/knife_cookbook_doc/attribute_model_spec.rb
+++ b/spec/knife_cookbook_doc/attribute_model_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe KnifeCookbookDoc::AttributesModel do
+  describe '#load_descriptions' do
+    before do
+      allow(IO)
+        .to receive(:read).with('attributes/default.rb').and_return(attributes)
+    end
+    let(:attributes) {
+<<EOS
+#<> Single line comment
+default['knife_cookbook_doc']['attr1'] = 'attr1_value'
+
+#<
+# Multiline comment with single line of text
+#>
+default['knife_cookbook_doc']['attr2'] = 'attr2_value'
+
+=begin
+#<
+Multiline begin/end with single line of text
+#>
+default['knife_cookbook_doc']['attr3'] = 'attr3_value'
+
+#<
+# Multiline comment with
+multiple lines of text
+#>
+default['knife_cookbook_doc']['attr4'] = 'attr4_value'
+
+=begin
+#<
+Multiline begin/end with
+multiple lines of text
+#>
+default['knife_cookbook_doc']['attr5'] = 'attr5_value'
+EOS
+    }
+    subject do
+      KnifeCookbookDoc::AttributesModel.new('attributes/default.rb').attributes
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "node['knife_cookbook_doc']['attr1']",
+          'Single line comment',
+          'attr1_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "node['knife_cookbook_doc']['attr2']",
+          'Multiline comment with single line of text',
+          'attr2_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "node['knife_cookbook_doc']['attr3']",
+          'Multiline begin/end with single line of text',
+          'attr3_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "node['knife_cookbook_doc']['attr4']",
+          "Multiline comment with\nmultiple lines of text",
+          'attr4_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "node['knife_cookbook_doc']['attr5']",
+          "Multiline begin/end with\nmultiple lines of text",
+          'attr5_value',
+          []
+        ]
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rspec'
+require_relative '../lib/knife_cookbook_doc/attributes_model'


### PR DESCRIPTION
I couldn't take the pain of messing this stuff up again. I added tests for all the different allowed syntax including testing both single and multiple lines of actual comment text in the multiline styles.

I think the issue with my previous request was that I was doing my manual testing on the multiline style but with only a single line of text. Removing the `/m` in that case does not cause a failure. As soon as the comment is multiline that breaks down.