### PR TITLE
Added Chef 12 support for issues_url/source_url in cookbook metadata

### DIFF
--- a/lib/chef/knife/README.md.erb
+++ b/lib/chef/knife/README.md.erb
@@ -149,6 +149,12 @@
 # License and Maintainer
 
 Maintainer:: <%= maintainer %> (<<%= maintainer_email %>>)
+<% unless source_url.empty? -%>
+<%= 'Source:: ' + source_url %>
+<% end -%>
+<% unless issues_url.empty? -%>
+<%= 'Issues:: ' + issues_url %> 
+<% end -%>
 
 License:: <%= license %>
 <% else -%>

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -66,8 +66,28 @@ module KnifeCookbookDoc
       @definitions
     end
 
+    def cookbook_name
+      @metadata.name
+    end
+
     def description
       @metadata.description
+    end
+
+    def source_url
+      if @metadata.methods.include? :source_url
+        @metadata.source_url
+      else
+        return ""
+      end
+    end
+
+    def issues_url
+      if @metadata.methods.include? :issues_url
+        @metadata.issues_url
+      else
+        return ""
+      end  
     end
 
     def platforms

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -78,7 +78,7 @@ module KnifeCookbookDoc
       if @metadata.methods.include? :source_url
         @metadata.source_url
       else
-        return ""
+        ""
       end
     end
 
@@ -86,7 +86,7 @@ module KnifeCookbookDoc
       if @metadata.methods.include? :issues_url
         @metadata.issues_url
       else
-        return ""
+        ""
       end  
     end
 

--- a/lib/knife_cookbook_doc/version.rb
+++ b/lib/knife_cookbook_doc/version.rb
@@ -1,3 +1,3 @@
 module KnifeCookbookDoc
-  VERSION = '1.0.0'
+  VERSION = '0.16.0-dev'
 end

--- a/lib/knife_cookbook_doc/version.rb
+++ b/lib/knife_cookbook_doc/version.rb
@@ -1,3 +1,3 @@
 module KnifeCookbookDoc
-  VERSION = '0.16.0-dev'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
Please can you review and merge this change, related to issue #16 

* It automatically adds Issues and Source URL to the generated README.md if present in cookbook metadata.
* Backwards compatible with Chef version < 12 were issues_url and source_rule methods are not defined. 