### PR TITLE
Let '# <' and '# >' also mark doc comment blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Expose metadata name value. Submitted by Mark Ayers.
 * No longer capitalize the platform. Submitted by Mark Ayers.
+* Allow '# <' and '# >' for doc block comments. Submitted by Mark Ayers.
 
 # v0.15.0 (Mar 20 2015)
 

--- a/lib/knife_cookbook_doc/attributes_model.rb
+++ b/lib/knife_cookbook_doc/attributes_model.rb
@@ -39,13 +39,13 @@ module KnifeCookbookDoc
       end
 
       # get/parse comments
-      resource_data = resource_data.gsub(/^=begin\s*\n\s*\#\<\s*\n(.*?)^\s*\#\>\n=end\s*\n#{ATTRIBUTE_REGEX}/m) do
+      resource_data = resource_data.gsub(/^=begin\s*\n\s*\#\ ?<\s*\n(.*?)^\s*\# ?\>\n=end\s*\n#{ATTRIBUTE_REGEX}/m) do
         update_attribute($2, $1)
       end
-      resource_data = resource_data.gsub(/^\s*\#\<\n(.*?)^\s*\#\>\n#{ATTRIBUTE_REGEX}/m) do
+      resource_data = resource_data.gsub(/^\s*\# ?\<\n(.*?)^\s*\# ?\>\n#{ATTRIBUTE_REGEX}/m) do
         update_attribute($2, $1.gsub(/^\s*\# ?/, ''))
       end
-      resource_data = resource_data.gsub(/^\s*\#\<\>\s(.*?$)\n#{ATTRIBUTE_REGEX}/) do
+      resource_data = resource_data.gsub(/^\s*\# ?\<\>\s(.*?$)\n#{ATTRIBUTE_REGEX}/) do
         update_attribute($2, $1)
       end
     end

--- a/lib/knife_cookbook_doc/base_model.rb
+++ b/lib/knife_cookbook_doc/base_model.rb
@@ -27,13 +27,13 @@ module KnifeCookbookDoc
 
     def extract_description
       description = []
-      IO.read(@filename).gsub(/^=begin *\n *\#\<\n(.*?)^ *\#\>\n=end *\n/m) do
+      IO.read(@filename).gsub(/^=begin *\n *\# ?\<\n(.*?)^ *\# ?\>\n=end *\n/m) do
         description << $1
         ""
-      end.gsub(/^ *\#\<\n(.*?)^ *\#\>\n/m) do
+      end.gsub(/^ *\# ?\<\n(.*?)^ *\# ?\>\n/m) do
         description << $1.gsub(/^ *\# ?/, '')
         ""
-      end.gsub(/^ *\#\<\> (.*?)$/) do
+      end.gsub(/^ *\# ?\<\> (.*?)$/) do
         description << $1
         ""
       end

--- a/spec/knife_cookbook_doc/attribute_model_spec.rb
+++ b/spec/knife_cookbook_doc/attribute_model_spec.rb
@@ -10,10 +10,18 @@ describe KnifeCookbookDoc::AttributesModel do
 #<> Single line comment
 default['knife_cookbook_doc']['attr1'] = 'attr1_value'
 
+# <> Another single line comment
+default['knife_cookbook_doc']['attr1x'] = 'attr1x_value'
+
 #<
 # Multiline comment with single line of text
 #>
 default['knife_cookbook_doc']['attr2'] = 'attr2_value'
+
+# <
+# Another multiline comment with single line of text
+# >
+default['knife_cookbook_doc']['attr2x'] = 'attr2x_value'
 
 =begin
 #<
@@ -22,11 +30,24 @@ Multiline begin/end with single line of text
 =end
 default['knife_cookbook_doc']['attr3'] = 'attr3_value'
 
+=begin
+# <
+Another multiline begin/end with single line of text
+# >
+=end
+default['knife_cookbook_doc']['attr3x'] = 'attr3x_value'
+
 #<
 # Multiline comment with
-multiple lines of text
+# multiple lines of text
 #>
 default['knife_cookbook_doc']['attr4'] = 'attr4_value'
+
+# <
+# Another multiline comment with
+# multiple lines of text
+# >
+default['knife_cookbook_doc']['attr4x'] = 'attr4x_value'
 
 =begin
 #<
@@ -35,6 +56,14 @@ multiple lines of text
 #>
 =end
 default['knife_cookbook_doc']['attr5'] = 'attr5_value'
+
+=begin
+# <
+Another multiline begin/end with
+multiple lines of text
+# >
+=end
+default['knife_cookbook_doc']['attr5x'] = 'attr5x_value'
 EOS
     }
     subject do
@@ -55,9 +84,31 @@ EOS
     it do
       is_expected.to include(
         [
+          "node['knife_cookbook_doc']['attr1x']",
+          'Another single line comment',
+          'attr1x_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
           "node['knife_cookbook_doc']['attr2']",
           'Multiline comment with single line of text',
           'attr2_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "node['knife_cookbook_doc']['attr2x']",
+          'Another multiline comment with single line of text',
+          'attr2x_value',
           []
         ]
       )
@@ -77,6 +128,17 @@ EOS
     it do
       is_expected.to include(
         [
+          "node['knife_cookbook_doc']['attr3x']",
+          'Another multiline begin/end with single line of text',
+          'attr3x_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
           "node['knife_cookbook_doc']['attr4']",
           "Multiline comment with\nmultiple lines of text",
           'attr4_value',
@@ -88,9 +150,31 @@ EOS
     it do
       is_expected.to include(
         [
+          "node['knife_cookbook_doc']['attr4x']",
+          "Another multiline comment with\nmultiple lines of text",
+          'attr4x_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
           "node['knife_cookbook_doc']['attr5']",
           "Multiline begin/end with\nmultiple lines of text",
           'attr5_value',
+          []
+        ]
+      )
+    end
+
+    it do
+      is_expected.to include(
+        [
+          "node['knife_cookbook_doc']['attr5x']",
+          "Another multiline begin/end with\nmultiple lines of text",
+          'attr5x_value',
           []
         ]
       )


### PR DESCRIPTION
As a chef cookbook author
Who likes using the ruby style guide: bbatsov/ruby-style-guide
And uses `rubocop -a`: bbatsov/rubocop
I want to deliminate doc comment blocks with `# `
So that I do not need to supress rubocop corrections