### PR TITLE
Expose name and do not capitalize platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.16.0 (Pending)
 
 * Expose metadata name value. Submitted by Mark Ayers.
+* No longer capitalize the platform. Submitted by Mark Ayers.
 
 # v0.15.0 (Mar 20 2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.16.0 (Pending)
 
+* Expose metadata name value. Submitted by Mark Ayers.
+
 # v0.15.0 (Mar 20 2015)
 
 * Further bug-fixes for multi-line attributes. Submitted By Drew Blessing.

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -87,7 +87,7 @@ module KnifeCookbookDoc
         @metadata.issues_url
       else
         ""
-      end  
+      end
     end
 
     def platforms
@@ -138,6 +138,10 @@ module KnifeCookbookDoc
 
     def license
       @metadata.license
+    end
+
+    def name
+      @metadata.name
     end
 
     def get_binding

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -92,7 +92,7 @@ module KnifeCookbookDoc
 
     def platforms
       @metadata.platforms.map do |platform, version|
-        format_constraint(platform.capitalize, version)
+        format_constraint(platform, version)
       end
     end
 


### PR DESCRIPTION
As a Chef cookbook author
I want to use the name metadata
So that I can use it as the top level heading README.md

As a Chef cookbook author
I do not want the platform capitalize for me
So that what I get is what I have given
Rather than a value I cannot control