### PR TITLE
Rake Task for cookbook doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,21 @@ Afterwards, the new knife command `knife cookbook doc DIR` will be available.
         knife cookbook doc path/to/cookbook
         knife cookbook doc path/to/cookbook --template README.md.erb
 
+Alternatively, you can execute cookbook doc directly from your Rakefile:
+
+    require 'knife_cookbook_doc/rake_task'
+
+    # With default options
+    KnifeCookbookDoc::RakeTask.new(:doc)
+
+    # Example with custom options
+    KnifeCookbookDoc::RakeTask.new(:doc) do |t|
+      t.options[:cookbook_dir] = './'
+      t.options[:constraints] = true
+      t.options[:output_file] = 'README.md'
+      t.options[:template_file] = "#{File.dirname(__FILE__)}/templates/README.md.erb"
+    end
+
 ## Further Details
 
 ### Documentation in comments

--- a/lib/knife_cookbook_doc/rake_task.rb
+++ b/lib/knife_cookbook_doc/rake_task.rb
@@ -13,7 +13,7 @@ require 'knife_cookbook_doc/attributes_model'
 
 module KnifeCookbookDoc
   class RakeTask < ::Rake::TaskLib
-    attr_accessor :name
+    attr_accessor :name, :options
 
     def initialize(name = :knife_cookbook_doc)
       @name = name
@@ -25,14 +25,14 @@ module KnifeCookbookDoc
     def define
       desc 'Generate cookbook documentation' unless ::Rake.application.last_comment
       task(name) do
-        options = @options.merge(default_options)
-        cookbook_dir = File.realpath(options[:cookbook_dir])
-        model = ReadmeModel.new(cookbook_dir, options[:constraints])
-        template = File.read(options[:template_file])
+        merged_options = default_options.merge(options)
+        cookbook_dir = File.realpath(merged_options[:cookbook_dir])
+        model = ReadmeModel.new(cookbook_dir, merged_options[:constraints])
+        template = File.read(merged_options[:template_file])
         eruby = Erubis::Eruby.new(template)
         result = eruby.result(model.get_binding)
 
-        File.open("#{cookbook_dir}/#{options[:output_file]}", 'wb') do |f|
+        File.open("#{cookbook_dir}/#{merged_options[:output_file]}", 'wb') do |f|
           result.each_line do |line|
             f.write line.gsub(/[ \t\r\n]*$/,'')
             f.write "\n"

--- a/lib/knife_cookbook_doc/rake_task.rb
+++ b/lib/knife_cookbook_doc/rake_task.rb
@@ -1,0 +1,54 @@
+require 'chef/cookbook/metadata'
+require 'erubis'
+require 'rake'
+require 'rake/tasklib'
+
+require 'knife_cookbook_doc/base_model'
+require 'knife_cookbook_doc/documenting_lwrp_base'
+require 'knife_cookbook_doc/definitions_model'
+require 'knife_cookbook_doc/readme_model'
+require 'knife_cookbook_doc/recipe_model'
+require 'knife_cookbook_doc/resource_model'
+require 'knife_cookbook_doc/attributes_model'
+
+module KnifeCookbookDoc
+  class RakeTask < ::Rake::TaskLib
+    attr_accessor :name
+
+    def initialize(name = :knife_cookbook_doc)
+      @name = name
+      @options = {}
+      yield self if block_given?
+      define
+    end
+
+    def define
+      desc 'Generate cookbook documentation' unless ::Rake.application.last_comment
+      task(name) do
+        options = @options.merge(default_options)
+        cookbook_dir = File.realpath(options[:cookbook_dir])
+        model = ReadmeModel.new(cookbook_dir, options[:constraints])
+        template = File.read(options[:template_file])
+        eruby = Erubis::Eruby.new(template)
+        result = eruby.result(model.get_binding)
+
+        File.open("#{cookbook_dir}/#{options[:output_file]}", 'wb') do |f|
+          result.each_line do |line|
+            f.write line.gsub(/[ \t\r\n]*$/,'')
+            f.write "\n"
+          end
+        end
+      end
+    end
+
+    private
+    def default_options
+      {
+        cookbook_dir: './',
+        constraints: true,
+        output_file: 'README.md',
+        template_file: Pathname.new("#{File.dirname(__FILE__)}/../chef/knife/README.md.erb").realpath
+      }
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I created a rake task, so cookbook doc can be invoked directly from the Rakefile, without the detour over sh / bundler / knife. This was basically just for a personal project, because I wanted to monkey patch some code into chef and cookbook doc before running. But it would be a shame to let the work go to waste.

It's not perfect, there is some duplication between the rake task and knife/cookbook_doc.rb. But it works fine for me so far. So I thought I just leave this here in case anyone wants to build on the idea. Take it or leave it :)