### PR TITLE
Fixes for more recent Chef versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 
 env:
   - CHEF_VERSION=master
+  - CHEF_VERSION=12.5.1
   - CHEF_VERSION=12.4.1
   - CHEF_VERSION=12.3.0
   - CHEF_VERSION=12.2.1

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The other text will be added at the start of the LWRP documentation
 except if marked with `@section <heading>`, in which case it will be added
 to the end of the LWRP documentation.
 
+Starting with Chef >12.5, properties will replace attributes in custom
+resources. For compatibility, `@property` may be used interchangibly with
+`@attribute`. Both will be handled completely identical by the plugin.
+
 #### Step 5
 
 In each definition add documentation like:

--- a/fixture/README-expected.md
+++ b/fixture/README-expected.md
@@ -39,7 +39,6 @@ This resource is awesome.
 ### Actions
 
 - stuff: Does awesome things. Default action.
-- nothing:
 
 ### Attribute Parameters
 

--- a/fixture/README-expected.md
+++ b/fixture/README-expected.md
@@ -28,6 +28,24 @@ The recipe is awesome. It does thing 1, thing 2 and thing 3!
 
 MyApp Admin Group: The group allowed to manage MyApp.
 
+# Resources
+
+* [fixture](#fixture) - This resource is awesome.
+
+## fixture
+
+This resource is awesome.
+
+### Actions
+
+- stuff: Does awesome things. Default action.
+- nothing:
+
+### Attribute Parameters
+
+- my_attribute: This is an attribute. Defaults to <code>"a default value"</code>.
+- my_property: This is a property. Defaults to <code>"another default value"</code>.
+
 # Credits
 
 * Mathias Lafeldt

--- a/fixture/resources/default.rb
+++ b/fixture/resources/default.rb
@@ -1,0 +1,16 @@
+#<
+# This resource is awesome.
+#>
+
+#<> @attribute my_attribute This is an attribute.
+attribute :my_attribute, default: 'a default value'
+
+#<> @property my_property This is a property.
+property :my_property, default: 'another default value'
+
+default_action :stuff
+
+#<> @action stuff Does awesome things.
+action :stuff do
+  # awesome things
+end

--- a/fixture/resources/default.rb
+++ b/fixture/resources/default.rb
@@ -1,16 +1,13 @@
 #<
 # This resource is awesome.
+#
+# @action stuff Does awesome things.
 #>
+
+default_action :stuff
 
 #<> @attribute my_attribute This is an attribute.
 attribute :my_attribute, default: 'a default value'
 
 #<> @property my_property This is a property.
 property :my_property, default: 'another default value'
-
-default_action :stuff
-
-#<> @action stuff Does awesome things.
-action :stuff do
-  # awesome things
-end

--- a/lib/chef/knife/README.md.erb
+++ b/lib/chef/knife/README.md.erb
@@ -120,8 +120,11 @@
 <% unless resource.actions.empty? -%>
 ### Actions
 
+<% if resource.default_action.is_a?(Array) %>
+- Default actions: [<%= resource.default_action.join ', ' %>]
+<% end %>
 <% resource.actions.each do |action| -%>
-- <%= action %>: <%= resource.action_description(action) %><% if resource.default_action == action %> Default action.<% end %>
+- <%= action %>: <%= resource.action_description(action) %><% if !resource.default_action.is_a?(Array) && resource.default_action == action %> Default action.<% end %>
 <% end -%>
 <% end -%>
 <% unless resource.attributes.empty? -%>

--- a/lib/knife_cookbook_doc/documenting_lwrp_base.rb
+++ b/lib/knife_cookbook_doc/documenting_lwrp_base.rb
@@ -18,7 +18,7 @@ class DocumentingLWRPBase < ::Chef::Resource::LWRPBase
     NOT_PASSED = defined?(::Chef::NOT_PASSED) ? ::Chef::NOT_PASSED : "NOT_PASSED"
     def property(name, type = NOT_PASSED, **options)
       attribute_specifications[name] = options
-      result = super(name, type, **options) if defined?(super)
+      super(name, type, **options) if defined?(super)
     end
   end
 

--- a/lib/knife_cookbook_doc/documenting_lwrp_base.rb
+++ b/lib/knife_cookbook_doc/documenting_lwrp_base.rb
@@ -17,10 +17,8 @@ class DocumentingLWRPBase < ::Chef::Resource::LWRPBase
 
     NOT_PASSED = defined?(::Chef::NOT_PASSED) ? ::Chef::NOT_PASSED : "NOT_PASSED"
     def property(name, type = NOT_PASSED, **options)
-      return unless defined?(super)
-      result = super(name, type, **options)
       attribute_specifications[name] = options
-      result
+      result = super(name, type, **options) if defined?(super)
     end
   end
 

--- a/lib/knife_cookbook_doc/documenting_lwrp_base.rb
+++ b/lib/knife_cookbook_doc/documenting_lwrp_base.rb
@@ -15,7 +15,9 @@ class DocumentingLWRPBase < ::Chef::Resource::LWRPBase
       @description || ""
     end
 
-    def property(name, type = ::Chef::NOT_PASSED, **options)
+    NOT_PASSED = defined?(::Chef::NOT_PASSED) ? ::Chef::NOT_PASSED : "NOT_PASSED"
+    def property(name, type = NOT_PASSED, **options)
+      return unless defined?(super)
       result = super(name, type, **options)
       attribute_specifications[name] = options
       result

--- a/lib/knife_cookbook_doc/documenting_lwrp_base.rb
+++ b/lib/knife_cookbook_doc/documenting_lwrp_base.rb
@@ -14,6 +14,12 @@ class DocumentingLWRPBase < ::Chef::Resource::LWRPBase
     def description
       @description || ""
     end
+
+    def property(name, type = ::Chef::NOT_PASSED, **options)
+      result = super(name, type, **options)
+      attribute_specifications[name] = options
+      result
+    end
   end
 
   def self.attribute(attr_name, validation_opts={})

--- a/lib/knife_cookbook_doc/resource_model.rb
+++ b/lib/knife_cookbook_doc/resource_model.rb
@@ -13,16 +13,22 @@ module KnifeCookbookDoc
       @native_resource.resource_name
     end
 
-    # Return the unique set of actions, with the default one first, if there is a default
+    # Return the unique set of actions, with the default one first, if there is a single default
     def actions
-      unless @actions
+      return @actions unless @actions.nil?
+
+      if default_action.is_a?(Array)
+        @actions = @native_resource.actions
+      else
         @actions = [default_action].compact + @native_resource.actions.sort.uniq.select { |a| a != default_action }
       end
       @actions
     end
 
     def default_action
-      @native_resource.default_action
+      action = @native_resource.default_action
+      return action.first if action.is_a?(Array) && action.length == 1
+      action
     end
 
     def action_description(action)

--- a/lib/knife_cookbook_doc/resource_model.rb
+++ b/lib/knife_cookbook_doc/resource_model.rb
@@ -14,6 +14,7 @@ module KnifeCookbookDoc
     end
 
     # Return the unique set of actions, with the default one first, if there is a single default
+    # The :nothing action will show up only if it is the only one, or it is  explicitly  documented
     def actions
       return @actions unless @actions.nil?
 
@@ -22,6 +23,8 @@ module KnifeCookbookDoc
       else
         @actions = [default_action].compact + @native_resource.actions.sort.uniq.select { |a| a != default_action }
       end
+
+      @actions.delete(:nothing) if @actions != [:nothing] && action_descriptions[:nothing].nil?
       @actions
     end
 

--- a/lib/knife_cookbook_doc/resource_model.rb
+++ b/lib/knife_cookbook_doc/resource_model.rb
@@ -65,7 +65,7 @@ module KnifeCookbookDoc
       @native_resource.description.each_line do |line|
         if /^ *\@action *([^ ]*) (.*)$/ =~ line
           action_descriptions[$1] = $2.strip
-        elsif /^ *\@attribute *([^ ]*) (.*)$/ =~ line
+        elsif /^ *(?:\@attribute|\@property) *([^ ]*) (.*)$/ =~ line
           attribute_descriptions[$1] = $2.strip
         elsif /^ *\@section (.*)$/ =~ line
           current_section = $1.strip


### PR DESCRIPTION
Hi,
I'm using Chef 12.5.1, and I noticed some minor problems when using cookbook doc with more recent Chef versions. So I sat down and started fixing them. Detailed changes are:

* Chef 12.5 introduced properties, which will replace attributes in the future. I added the property function to the documenting lwrp base so they are picked up properly alongside attributes. The function will be available, even in Chef < 12.5, which is weird but at least cookbook doc will behave consistently across Chef versions. I also added the `@property` annotation, which is identical to `@attribute`.
* `default_action` is now a list of actions by default (not sure if this is new in 12.5 or older), which looked weird in the generated documentation. Fixed it so it looks nice no matter whether its a list or a single action.
* The `:nothing` action is always an allowed action on the resource, but for older Chef versions, it wouldn't show up in the generated documentation (which is nicer in my opinion). Fixed it so the the `:nothing` action will be filtered out unless it is the only action on the resource, or it is explicitly documented via the `@action` annotation.
* Created a custom resource in the test fixture and added a result to the expected README.md, so these changes to lwrp documentation are tested.
* I also added 12.5.1 to the list of Chef versions tested by Travis CI