### PR TITLE
Add "--ignore-missing-doc-attr" option to ignore undocumented attributes

### DIFF
--- a/lib/chef/knife/cookbook_doc.rb
+++ b/lib/chef/knife/cookbook_doc.rb
@@ -36,6 +36,12 @@ module KnifeCookbookDoc
            :default => Pathname.new("#{File.dirname(__FILE__)}/README.md.erb").realpath,
            :description => 'Set template file used to render README.md'
 
+    option :ignore_missing_attribute_desc,
+           :long => '--ignore-missing-doc-attr',
+           :boolean => true,
+           :default => false,
+           :description => 'Ignore attributes without documetation'
+
     def run
       unless (cookbook_dir = name_args.first)
         ui.fatal 'Please provide cookbook directory as an argument'
@@ -44,7 +50,7 @@ module KnifeCookbookDoc
 
       cookbook_dir = File.realpath(cookbook_dir)
 
-      model = ReadmeModel.new(cookbook_dir, config[:constraints])
+      model = ReadmeModel.new(cookbook_dir, config)
 
       template = File.read(config[:template_file])
       eruby = Erubis::Eruby.new(template)

--- a/lib/knife_cookbook_doc/attributes_model.rb
+++ b/lib/knife_cookbook_doc/attributes_model.rb
@@ -3,9 +3,10 @@ module KnifeCookbookDoc
 
     ATTRIBUTE_REGEX = "(^\s*(?:default|set|force_default|override|force_override).*?)=\s*\n?\s*(.*?)$".freeze
 
-    def initialize(filename)
+    def initialize(filename, config)
       @filename = filename
       @attributes = {}
+      @config = config
       load_descriptions
     end
 
@@ -47,6 +48,10 @@ module KnifeCookbookDoc
       end
       resource_data = resource_data.gsub(/^\s*\# ?\<\>\s(.*?$)\n#{ATTRIBUTE_REGEX}/) do
         update_attribute($2, $1)
+      end
+
+      if @config[:ignore_missing_attribute_desc]
+        @attributes.select! { |att_name, att_options| att_options.has_key? :description }
       end
     end
 

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -2,7 +2,7 @@ module KnifeCookbookDoc
   class ReadmeModel
     DEFAULT_CONSTRAINT = ">= 0.0.0".freeze
 
-    def initialize(cookbook_dir, constraints)
+    def initialize(cookbook_dir, config)
 
       @metadata = Chef::Cookbook::Metadata.new
       @metadata.from_file("#{cookbook_dir}/metadata.rb")
@@ -15,7 +15,7 @@ module KnifeCookbookDoc
       else
         @attributes = []
         Dir["#{cookbook_dir}/attributes/*.rb"].sort.each do |attribute_filename|
-          model = AttributesModel.new(attribute_filename)
+          model = AttributesModel.new(attribute_filename, config)
           if !model.attributes.empty?
             @attributes += model.attributes
           end
@@ -51,7 +51,7 @@ module KnifeCookbookDoc
         end
       end
       @metadata = @metadata
-      @constraints = constraints
+      @constraints = config[:constraints]
     end
 
     def fragments


### PR DESCRIPTION
This can be used to cleanup the README file when starting to document a cookbook
with a lot of existing attributes.
Another use case is with nested trees of related attributes where it would make sense to create a documentation block for the tree root only.