### PR TITLE
Fix: markdown spacing for maintainer/source/issues URL

### DIFF
--- a/lib/chef/knife/README.md.erb
+++ b/lib/chef/knife/README.md.erb
@@ -156,9 +156,11 @@
 # License and Maintainer
 
 Maintainer:: <%= maintainer %> (<<%= maintainer_email %>>)
+
 <% unless source_url.empty? -%>
 <%= 'Source:: ' + source_url %>
 <% end -%>
+
 <% unless issues_url.empty? -%>
 <%= 'Issues:: ' + issues_url %>
 <% end -%>


### PR DESCRIPTION
Without this patch, although the Maintainer/Source URL and Issues URL
are on separate lines:

    Maintainer:: Jamie Tanna (<chef@jamietanna.co.uk>)
    Source:: https://gitlab.com/spectat/provisioning/cookbook-spectat
    Issues:: https://gitlab.com/spectat/provisioning/cookbook-spectat/issues

However, markdown rendering will place them on a
single line ([GitHub-pre](https://gist.github.com/jamietanna/2801c526360a591ee1d22c320dab3381#file-pre-readme-md), [GitLab-pre](https://gitlab.com/snippets/1677506#license-and-maintainer)) when displaying them:

With this patch, the lines are broken with newlines:

    Maintainer:: Jamie Tanna (<chef@jamietanna.co.uk>)

    Source:: https://gitlab.com/spectat/provisioning/cookbook-spectat

    Issues:: https://gitlab.com/spectat/provisioning/cookbook-spectat/issues

This means that they will be rendered correctly on separate
lines ([GitHub-post](https://gist.github.com/jamietanna/2801c526360a591ee1d22c320dab3381#file-post-readme-md), [GitLab-post](https://gitlab.com/snippets/1677506#license-and-maintainer-1)).