### PR TITLE
Fix: Remove deprecated metadata for >= Chef 13

### DIFF
--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -103,20 +103,32 @@ module KnifeCookbookDoc
     end
 
     def recommendations
-      @metadata.recommendations.map do |cookbook, version|
-        format_constraint(cookbook, version)
+      if @metadata.methods.include?(:recommendations)
+        @metadata.recommendations.map do |cookbook, version|
+          format_constraint(cookbook, version)
+        end
+      else
+        []
       end
     end
 
     def suggestions
-      @metadata.suggestions.map do |cookbook, version|
-        format_constraint(cookbook, version)
+      if @metadata.methods.include?(:suggestions)
+        @metadata.suggestions.map do |cookbook, version|
+          format_constraint(cookbook, version)
+        end
+      else
+        []
       end
     end
 
     def conflicting
-      @metadata.conflicting.map do |cookbook, version|
-        format_constraint(cookbook, version)
+      if @metadata.methods.include?(:conflicting)
+        @metadata.conflicting.map do |cookbook, version|
+          format_constraint(cookbook, version)
+        end
+      else
+        []
       end
     end
 


### PR DESCRIPTION
As per Chef 13's release notes[0], `recommends`, `suggests`,
`conflicts`, `replaces` and `grouping` have all been removed from having
any sway on `metadata.rb`. Therefore, when we run this under Chef 13, we
receive the following, erroneous, output:

    * #<Logger:0x0000000004397548> () (Recommended but not required)
    * #<Logger:0x0000000004397548> () (Suggested but not required)
    * Conflicts with #<Logger:0x0000000004397548> ()

In the cases where the `Chef::Cookbook::Metadata` instance does not
have these methods (i.e. >= Chef 13) then return an empty array, which
will not be iterated over in `lib/chef/knife/README.md.erb`. This also
ensures backwards compatibility with older versions of Chef, as it will
proceed as before if the methods exist.

[0]: https://docs.chef.io/release_notes.html#deprecated-cookbook-metadata-has-been-removed