### PR TITLE
Add chef_versions support

### DIFF
--- a/fixture/README-expected.md
+++ b/fixture/README-expected.md
@@ -6,6 +6,11 @@
 
 # Requirements
 
+
+## Chef Client:
+
+*No Chef versions defined*
+
 ## Platform:
 
 * cookbook-authors

--- a/lib/chef/knife/README.md.erb
+++ b/lib/chef/knife/README.md.erb
@@ -12,6 +12,17 @@
 <%= fragments['requirements'] -%>
 
 <% end -%>
+
+## Chef Client:
+
+<% unless chef_versions.empty? %>
+<% chef_versions.each do |chef_version| %>
+* <%= chef_version %>
+<% end %>
+<% else %>
+*No Chef versions defined*
+<% end %>
+
 ## Platform:
 
 <% unless platforms.empty? %>

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -96,6 +96,12 @@ module KnifeCookbookDoc
       end
     end
 
+    def chef_versions
+      @metadata.chef_versions.map do |chef_version, version|
+        format_constraint(chef_version, version)
+      end
+    end
+
     def dependencies
       @metadata.dependencies.map do |cookbook, version|
         format_constraint(cookbook, version)

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -97,8 +97,12 @@ module KnifeCookbookDoc
     end
 
     def chef_versions
-      @metadata.chef_versions.map do |chef_version, version|
-        format_constraint(chef_version, version)
+      if @metadata.methods.include?(:chef_version)
+        @metadata.chef_versions.map do |chef_version, version|
+          format_constraint(chef_version, version)
+        end
+      else
+        []
       end
     end
 


### PR DESCRIPTION
Hello.

Thank you for this project! It's very convenient to generate documentation automatically.

With this PR I would like to add support of chef_versions from metadata.rb.
I tested this feature and I hope it will be merged so everyone can be able to use it.