### PR TITLE
Prettify Chef version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ gemfile: fixture/gemfile
 rvm:
   - 2.2.6
   - 2.3.3
+  - 2.6.7
+  - 2.7.3
 
 env:
   - CHEF_VERSION=master
+  - CHEF_VERSION=12.6.0
   - CHEF_VERSION=12.5.1
   - CHEF_VERSION=12.4.1
   - CHEF_VERSION=12.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,19 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - env: CHEF_VERSION=11.12.8
+    - env: CHEF_VERSION=11.12.8 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
       rvm: 2.3.3
-    - env: CHEF_VERSION=11.10.4
+    - env: CHEF_VERSION=11.10.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
       rvm: 2.3.3
+    - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+      rvm: 2.2.6
+    - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+      rvm: 2.3.3
+    - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+      rvm: 2.6.7
 
   allow_failures:
-    - env: CHEF_VERSION=master
+    - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
 
 script:
   - cd fixture

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ rvm:
 
 env:
   - CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+  - CHEF_VERSION=16.13.16 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+  - CHEF_VERSION=15.17.4 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
   - CHEF_VERSION=12.6.0 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
   - CHEF_VERSION=12.5.1 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
   - CHEF_VERSION=12.4.1 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
@@ -37,6 +39,15 @@ matrix:
       rvm: 2.3.3
     - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
       rvm: 2.6.7
+    # Newer Chef does not work with old Ruby
+    - env: CHEF_VERSION=16.13.16 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+      rvm: 2.2.6
+    - env: CHEF_VERSION=15.17.4 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+      rvm: 2.2.6
+    - env: CHEF_VERSION=16.13.16 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+      rvm: 2.3.3
+    - env: CHEF_VERSION=15.17.4 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+      rvm: 2.3.3
     # Old Chef bundles old json package incompatible with newer Ruby
     - env: CHEF_VERSION=12.1.2 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
       rvm: 2.6.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,42 @@ matrix:
       rvm: 2.3.3
     - env: CHEF_VERSION=11.10.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
       rvm: 2.3.3
+    # As of May 28 2021, chef/chef master requires 2.7 or higher
     - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
       rvm: 2.2.6
     - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
       rvm: 2.3.3
     - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
       rvm: 2.6.7
+    # Old Chef bundles old json package incompatible with newer Ruby
+    - env: CHEF_VERSION=12.1.2 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.6.7
+    - env: CHEF_VERSION=12.1.2 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.7.3
+    - env: CHEF_VERSION=12.0.3 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.6.7
+    - env: CHEF_VERSION=12.0.3 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.7.3
+    - env: CHEF_VERSION=11.18.12 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.6.7
+    - env: CHEF_VERSION=11.18.12 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.7.3
+    - env: CHEF_VERSION=11.16.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.6.7
+    - env: CHEF_VERSION=11.16.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.7.3
+    - env: CHEF_VERSION=11.14.6 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.6.7
+    - env: CHEF_VERSION=11.14.6 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.7.3
+    - env: CHEF_VERSION=11.12.8 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.6.7
+    - env: CHEF_VERSION=11.12.8 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.7.3
+    - env: CHEF_VERSION=11.10.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.6.7
+    - env: CHEF_VERSION=11.10.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+      rvm: 2.7.3
 
   allow_failures:
     - env: CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,19 @@ rvm:
   - 2.7.3
 
 env:
-  - CHEF_VERSION=master
-  - CHEF_VERSION=12.6.0
-  - CHEF_VERSION=12.5.1
-  - CHEF_VERSION=12.4.1
-  - CHEF_VERSION=12.3.0
-  - CHEF_VERSION=12.2.1
-  - CHEF_VERSION=12.1.2
-  - CHEF_VERSION=12.0.3
-  - CHEF_VERSION=11.18.12
-  - CHEF_VERSION=11.16.4
-  - CHEF_VERSION=11.14.6
-  - CHEF_VERSION=11.12.8
-  - CHEF_VERSION=11.10.4
+  - CHEF_VERSION=master EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+  - CHEF_VERSION=12.6.0 EXPECTED_FILE=README-expected.md METADATA=metadata.rb
+  - CHEF_VERSION=12.5.1 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=12.4.1 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=12.3.0 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=12.2.1 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=12.1.2 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=12.0.3 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=11.18.12 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=11.16.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=11.14.6 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=11.12.8 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
+  - CHEF_VERSION=11.10.4 EXPECTED_FILE=README-expected_legacy.md METADATA=metadata_legacy.rb
 
 matrix:
   fast_finish: true
@@ -36,5 +36,5 @@ matrix:
 
 script:
   - cd fixture
-  - bundle exec knife cookbook doc . -o README-generated.md -c knife.rb
-  - diff README-expected.md README-generated.md && rm README-generated.md
+  - bundle exec knife cookbook doc . -o README-generated.md -c knife.rb --metadata $METADATA
+  - diff $EXPECTED_FILE README-generated.md && rm README-generated.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Prettify Chef version constraints.
+
 # v0.30.0 (Mar 19 2021)
 
 * Support a space after # in custom resource. Submitted by Tomoya Kabe.

--- a/fixture/README-expected.md
+++ b/fixture/README-expected.md
@@ -9,7 +9,8 @@
 
 ## Chef Client:
 
-*No Chef versions defined*
+* chef (>= 14.0, < 16.0)
+* chef (= 12.0)
 
 ## Platform:
 

--- a/fixture/README-expected_legacy.md
+++ b/fixture/README-expected_legacy.md
@@ -1,0 +1,75 @@
+# Description
+
+# My Cookbook Readme
+
+**`knife cookbook doc .` _rocks_**
+
+# Requirements
+
+
+## Chef Client:
+
+*No Chef versions defined*
+
+## Platform:
+
+* cookbook-authors
+
+## Cookbooks:
+
+* upon-magic
+
+# Attributes
+
+* `node['knife']['cookbook']['doc']` -  Defaults to `successful automation`.
+
+# Recipes
+
+* [fixture::default](#fixturedefault) - The recipe is awesome.
+
+## fixture::default
+
+The recipe is awesome. It does thing 1, thing 2 and thing 3!
+
+MyApp Admin Group: The group allowed to manage MyApp.
+
+# Resources
+
+* [fixture](#fixture) - This resource is awesome.
+* [fixture_space](#fixture_space) - This resource is spacial.
+
+## fixture
+
+This resource is awesome.
+
+### Actions
+
+- stuff: Does awesome things. Default action.
+
+### Attribute Parameters
+
+- my_attribute: This is an attribute. Defaults to <code>"a default value"</code>.
+- my_property: This is a property. Defaults to <code>"another default value"</code>.
+
+## fixture_space
+
+This resource is spacial.
+
+### Actions
+
+- stuff: Inserts spaces. Default action.
+
+### Attribute Parameters
+
+- my_attribute: This is an attribute. Defaults to <code>"a default value"</code>.
+- my_property: This is a property. Defaults to <code>"another default value"</code>.
+
+# Libraries
+
+## stooges()
+Returns `['Moe', 'Larry', 'Curly']`
+
+# Credits
+
+* Mathias Lafeldt
+* Peter Donald

--- a/fixture/gemfile
+++ b/fixture/gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org/'
 
 if ENV['CHEF_VERSION'] == 'master'
   gem 'chef', github: 'chef/chef'
+  gem 'knife', github: 'chef/chef'
 else
   gem 'chef', ENV['CHEF_VERSION']
 end

--- a/fixture/metadata.rb
+++ b/fixture/metadata.rb
@@ -5,6 +5,8 @@ license          'MIT'
 description      'Installs/Configures fixture'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
+chef_version     '>= 14.0', '< 16.0'
+chef_version     '= 12.0'
 
 supports 'cookbook-authors'
 depends 'upon-magic'

--- a/fixture/metadata_legacy.rb
+++ b/fixture/metadata_legacy.rb
@@ -1,0 +1,10 @@
+name             'fixture'
+maintainer       'A Cookbook Author'
+maintainer_email 'author@example.com'
+license          'MIT'
+description      'Installs/Configures fixture'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'
+
+supports 'cookbook-authors'
+depends 'upon-magic'

--- a/lib/chef/knife/cookbook_doc.rb
+++ b/lib/chef/knife/cookbook_doc.rb
@@ -43,6 +43,11 @@ module KnifeCookbookDoc
            :default => false,
            :description => 'Ignore attributes without documetation'
 
+    option :metadata,
+           :long => '--metadata FILE',
+           :default => 'metadata.rb',
+           :description => 'metadata.rb path'
+
     def run
       unless (cookbook_dir = name_args.first)
         ui.fatal 'Please provide cookbook directory as an argument'

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -110,8 +110,9 @@ module KnifeCookbookDoc
 
     def chef_versions
       if @metadata.methods.include?(:chef_version)
-        @metadata.chef_versions.map do |chef_version, version|
-          format_constraint(chef_version, version)
+        @metadata.chef_versions.map do |chef_version|
+          constraints = chef_version.requirements_list.join(', ')
+          format_constraint(chef_version.name, constraints)
         end
       else
         []

--- a/lib/knife_cookbook_doc/readme_model.rb
+++ b/lib/knife_cookbook_doc/readme_model.rb
@@ -13,7 +13,7 @@ module KnifeCookbookDoc
     def initialize(cookbook_dir, config)
 
       @metadata = Chef::Cookbook::Metadata.new
-      @metadata.from_file("#{cookbook_dir}/metadata.rb")
+      @metadata.from_file("#{cookbook_dir}/#{config[:metadata]}")
 
       if (!@metadata.attributes.empty? rescue false)
         @attributes = @metadata.attributes.map do |attr, options|


### PR DESCRIPTION
When `chef_version` constraints are written in `metadata.rb`, the current implementation generates like below, with unnecessary parenthesis at the end of the lines.

```
* chef (>= 14.0, < 16.0) ()
* chef (= 12.0) ()
```

This is because `@metadata.chef_versions` is an array of `Gem::Dependency`, so calling with this as Hash is inappropriate.

This PR prettifies this dependency generation by passing the appropriate arguments to the formatter.