### PR TITLE
Remove action class from resouce text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# v 0.31.1 (March 14 2022)
+
+* Remove `action_class` from data sent to `resource_class.class_eval`.  Submitted by Justin Steele.
+
 # v0.31.0 (Feb 7 2022)
 
 * Prettify Chef version constraints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# v 0.31.1 (March 14 2022)
+# v0.31.1 (Sep 5 2022)
 
 * Remove `action_class` from data sent to `resource_class.class_eval`.  Submitted by Justin Steele.
 

--- a/fixture/resources/space.rb
+++ b/fixture/resources/space.rb
@@ -11,3 +11,7 @@ attribute :my_attribute, default: 'a default value'
 
 # <> @property my_property This is a property.
 property :my_property, default: 'another default value'
+
+action_class do
+  include FixtureCookbook::Library
+end

--- a/lib/knife_cookbook_doc/resource_model.rb
+++ b/lib/knife_cookbook_doc/resource_model.rb
@@ -107,6 +107,9 @@ module KnifeCookbookDoc
       resource_data = resource_data.gsub(/^ *\# ?\<\> (.*?)$/) do
         "desc #{$1.inspect}\n"
       end
+      resource_data = resource_data.gsub(/^action_class do\n(.*?)\nend/m) do
+        ''
+      end
 
       resource_class.class_eval(resource_data, filename, 1)
 

--- a/lib/knife_cookbook_doc/version.rb
+++ b/lib/knife_cookbook_doc/version.rb
@@ -1,3 +1,3 @@
 module KnifeCookbookDoc
-  VERSION = '0.31.0'
+  VERSION = '0.31.1'
 end

--- a/spec/knife_cookbook_doc/resource_model_spec.rb
+++ b/spec/knife_cookbook_doc/resource_model_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe KnifeCookbookDoc::ResourceModel do
+  describe '#load_descriptions' do
+    subject do
+      KnifeCookbookDoc::ResourceModel.new('fixture', './fixture/resources/space.rb').name
+    end
+
+    it do
+      is_expected.to eq(:fixture_space)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 require 'rspec'
+require 'chef'
 require_relative '../lib/knife_cookbook_doc/attributes_model'
+require_relative '../lib/knife_cookbook_doc/base_model'
+require_relative '../lib/knife_cookbook_doc/resource_model'
+require_relative '../lib/knife_cookbook_doc/documenting_lwrp_base'


### PR DESCRIPTION
When `action_class` includes libraries, the `resource_model` fails to compile.  For example:

``` ruby
action_class do
  include MyCookbook::MyLibrary
end
```
would result in the following error:
```
in `block in build_native_from_file': uninitialized constant #<Class:0x00007fdcc2244e78>::MyCookbook (NameError)
```

Given the contents of the `action_class` is not particularly useful for documenting the resource, this change removes all of the `action_class` text such that the document can be created.